### PR TITLE
Bug 1234831: support listing secrets

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -146,6 +146,27 @@ api.declare({
   }
 });
 
+api.declare({
+  method:      'get',
+  route:       '/secrets',
+  deferAuth:   true,
+  name:        'list',
+  output:      common.SCHEMA_PREFIX_CONST + "secret-list.json#",
+  title:       'List Secrets',
+  description: 'List the names of all visible secrets.'
+}, async function(req, res) {
+  // TODO: filter these by visibility
+  let secrets = [];
+  await this.entity.scan({}, {
+    handler: (item) => {
+      // note: req.satisifies sets the HTTP response if it fails,
+      // so it can't be used to check each item
+      secrets.push(item.name);
+    }
+  });
+  return res.reply({secrets});
+});
+
 /** Check that the server is a alive */
 api.declare({
   method:   'get',

--- a/lib/api.js
+++ b/lib/api.js
@@ -155,13 +155,12 @@ api.declare({
   title:       'List Secrets',
   description: 'List the names of all visible secrets.'
 }, async function(req, res) {
-  // TODO: filter these by visibility
   let secrets = [];
   await this.entity.scan({}, {
     handler: (item) => {
-      // note: req.satisifies sets the HTTP response if it fails,
-      // so it can't be used to check each item
-      secrets.push(item.name);
+      if (req.satisfies([["secrets:get:" + item.name]], true)) {
+        secrets.push(item.name);
+      }
     }
   });
   return res.reply({secrets});

--- a/schemas/secret-list.yml
+++ b/schemas/secret-list.yml
@@ -1,0 +1,18 @@
+id: http://schemas.taskcluster.net/secrets/v1/secret-list.json#
+$schema:  http://json-schema.org/draft-04/schema#
+title:        "A list of TaskCluster Secrets"
+description: |
+  Message containing a list of secret names
+type:         object
+properties:
+  secrets:
+    description: Secret names
+    type:         array
+    items:
+      title: Secret
+      description: Secret name
+      type: string
+additionalProperties: false
+required:
+  - secrets
+

--- a/test/helper.js
+++ b/test/helper.js
@@ -65,6 +65,13 @@ var testClients = [
     ],
     expiry:       ClientExpiration,
     credentials:  cfg.get('taskcluster:credentials')
+  }, {
+    clientId:     'captain-read-limited',
+    scopes:       [
+      'secrets:get:captain:limited/*'
+    ],
+    expiry:       ClientExpiration,
+    credentials:  cfg.get('taskcluster:credentials')
   }
 ];
 

--- a/test/taskcluster_secrets_api_test.js
+++ b/test/taskcluster_secrets_api_test.js
@@ -237,9 +237,9 @@ suite("TaskCluster-Secrets", () => {
     list.secrets.sort();
     assert.deepEqual(list, {secrets: ['captain:hidden/1', 'captain:limited/1']})
 
-    // the limited client can see both, too
+    // the limited client can only see the limited secret, too
     list = await secrets_limited.list();
     list.secrets.sort();
-    assert.deepEqual(list, {secrets: ['captain:hidden/1', 'captain:limited/1']})
+    assert.deepEqual(list, {secrets: ['captain:limited/1']})
   });
 });

--- a/test/taskcluster_secrets_api_test.js
+++ b/test/taskcluster_secrets_api_test.js
@@ -207,4 +207,39 @@ suite("TaskCluster-Secrets", () => {
     }
     assert(false, "Expected an error");
   });
+
+  test("List secrets", async () => {
+    let secrets_rw = helper.clients['captain-read-write'];
+    let secrets_limited = helper.clients['captain-read-limited'];
+
+    // delete any secrets we can see
+    let list = await secrets_rw.list();
+    for (let secret of list.secrets) {
+      await secrets_rw.remove(secret);
+    }
+
+    // assert the list is empty
+    list = await secrets_rw.list();
+    assert.deepEqual(list, {secrets: []})
+
+    // create some
+    await secrets_rw.set('captain:hidden/1', {
+      secret: {'sekrit': 1},
+      expires: taskcluster.fromNowJSON('2 hours')
+    });
+    await secrets_rw.set('captain:limited/1', {
+      secret: {'less-sekrit': 1},
+      expires: taskcluster.fromNowJSON('2 hours')
+    });
+
+    // secrets_rw can see both
+    list = await secrets_rw.list();
+    list.secrets.sort();
+    assert.deepEqual(list, {secrets: ['captain:hidden/1', 'captain:limited/1']})
+
+    // the limited client can see both, too
+    list = await secrets_limited.list();
+    list.secrets.sort();
+    assert.deepEqual(list, {secrets: ['captain:hidden/1', 'captain:limited/1']})
+  });
 });


### PR DESCRIPTION
For the moment, the best we can do is to list all secrets regardless of
scopes.

@jonasfj I'm curious what you think.  It wouldn't be hard to add a `req.authorizedScopes` attribute and call `scopeMatch` for each item in the table.  But is this too much scanning?

I really don't want to go to the hierarchical model for this, not least because then we're faced with translating scopePatterns back into a set of hierarchical queries, depending on what separator(s) we have chosen.  Sounds complex and buggy.

I'm not terribly opposed to allowing anyone to list all secrets, but it does feel unnecessarily open.

@mrrrgn happy to hear your thoughts here too.