### PR TITLE
Rename AListOfTaskClusterSecrets to SecretsList in generated go/java code

### DIFF
--- a/schemas/secret-list.yml
+++ b/schemas/secret-list.yml
@@ -1,6 +1,6 @@
 id: http://schemas.taskcluster.net/secrets/v1/secret-list.json#
 $schema:  http://json-schema.org/draft-04/schema#
-title:        "A list of TaskCluster Secrets"
+title:        "Secrets List"
 description: |
   Message containing a list of secret names
 type:         object


### PR DESCRIPTION
This fixes the name in the [generated go client library](https://godoc.org/github.com/taskcluster/taskcluster-client-go/secrets#AListOfTaskClusterSecrets), and in the [generated java client library](http://taskcluster.github.io/taskcluster-client-java/apidocs/org/mozilla/taskcluster/client/secrets/AListOfTaskClusterSecrets.html).

AListOfTaskClusterSecrets => SecretsList