### PR TITLE
Remove old docker image from tests

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -16,12 +16,12 @@ tasks:
           - pull_request.reopened
     payload:
       maxRunTime: 3600
-      image: "quay.io/mrrrgn/ubuntu-ci:0.0.1"
+      image: "node:6"
       command:
         - "/bin/bash"
         - "--login"
         - "-c"
-        - "checkout-pull-request && npm install . && npm test"
+        - "git clone {{event.head.repo.url}} repo && cd repo && git checkout {{event.head.sha}} && npm install . && npm test"
     metadata:
       name: "TaskCluster Secrets Tests"
       description: "All non-integration tests"


### PR DESCRIPTION
https://quay.io/repository/mrrrgn/ubuntu-ci?tag=latest&tab=tags hasn't been updated in a long time and has a bunch of security issues. I don't believe anybody other than this repo uses it.