### PR TITLE
Bug 1400550 - don't try to authorize each secret name

### DIFF
--- a/schemas/secret-list.yml
+++ b/schemas/secret-list.yml
@@ -11,6 +11,17 @@ properties:
       title: Secret
       description: Secret name
       type: string
+  continuationToken:
+    type:             string
+    title:            "Continuation Token"
+    description: |
+      Opaque `continuationToken` to be given as query-string option to get the
+      next set of provisioners.
+      This property is only present if another request is necessary to fetch all
+      results. In practice the next request with a `continuationToken` may not
+      return additional results, but it can. Thus, you can only be sure to have
+      all the results if you've called with `continuationToken` until you get a
+      result without a `continuationToken`.
 additionalProperties: false
 required:
   - secrets

--- a/src/api.js
+++ b/src/api.js
@@ -31,7 +31,6 @@ let cleanPayload = payload => {
 api.declare({
   method:      'put',
   route:       '/secret/:name(*)',
-  deferAuth:   true,
   name:        'set',
   input:       SCHEMA_PREFIX_CONST + 'secret.json#',
   scopes:      [['secrets:set:<name>']],
@@ -45,9 +44,6 @@ api.declare({
 }, async function(req, res) {
   let {name} = req.params;
   let {secret, expires} = req.body;
-  if (!req.satisfies({name})) {
-    return;
-  }
   try {
     await this.entity.create({
       name:       name,
@@ -70,7 +66,6 @@ api.declare({
 api.declare({
   method:      'delete',
   route:       '/secret/:name(*)',
-  deferAuth:   true,
   name:        'remove',
   scopes:      [['secrets:set:<name>']],
   title:       'Delete Secret',
@@ -80,9 +75,6 @@ api.declare({
   ].join('\n'),
 }, async function(req, res) {
   let {name} = req.params;
-  if (!req.satisfies({name})) {
-    return;
-  }
   try {
     await this.entity.remove({name: name});
   } catch (e) {
@@ -98,7 +90,6 @@ api.declare({
 api.declare({
   method:      'get',
   route:       '/secret/:name(*)',
-  deferAuth:   true,
   name:        'get',
   output:      SCHEMA_PREFIX_CONST + 'secret.json#',
   scopes:      [['secrets:get:<name>']],
@@ -112,9 +103,6 @@ api.declare({
   ].join('\n'),
 }, async function(req, res) {
   let {name} = req.params;
-  if (!req.satisfies({name})) {
-    return;
-  }
   let item = undefined;
   try {
     item = await this.entity.load({name});

--- a/test/taskcluster_secrets_api_test.js
+++ b/test/taskcluster_secrets_api_test.js
@@ -235,14 +235,8 @@ suite('TaskCluster-Secrets', () => {
       expires: taskcluster.fromNowJSON('2 hours'),
     });
 
-    // secrets_rw can see both
     list = await secrets_rw.list();
     list.secrets.sort();
     assert.deepEqual(list, {secrets: ['captain:hidden/1', 'captain:limited/1']});
-
-    // the limited client can only see the limited secret, too
-    list = await secrets_limited.list();
-    list.secrets.sort();
-    assert.deepEqual(list, {secrets: ['captain:limited/1']});
   });
 });

--- a/test/taskcluster_secrets_api_test.js
+++ b/test/taskcluster_secrets_api_test.js
@@ -91,6 +91,13 @@ suite('TaskCluster-Secrets', () => {
       res:        testValueExpires2,
     },
     {
+      testName:   'Captain (read only), delete key not permitted',
+      clientName: 'captain-read',
+      apiCall:    'remove',
+      name:        'captain:' + FOO_KEY,
+      statusCode: 403, // It's not authorized!
+    },
+    {
       testName:   'Captain (write only), delete foo.',
       clientName: 'captain-write',
       apiCall:    'remove',


### PR DESCRIPTION
The upshot is, where before we've hidden all secret names unless you have the scopes to get them, now we just show all secret names (not content!) to everyone.

This would be required to support https://github.com/taskcluster/taskcluster-rfcs/issues/23 (in fact, we'll need to ensure that each API endpoint calls req.satisfies at most once for that RFC).  It also avoids multiple "Authorized ..." log lines.

I don't really believe in security by obscurity, so I tend to think it's OK to show secret names.  But I could be wrong.  An alternative is to not allow listing secrets at all, just like we don't allow listing tasks.