### PR TITLE
Minor tweaks to make r14y work well

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -63,7 +63,6 @@ production:
   server:
     port:                         80
     env:                          'production'
-    forceSSL:                     true
     # We trust the proxy on heroku, as the SSL end-point provided by heroku
     # is a proxy, so we have to trust it.
     trustProxy:                   true

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "nock": "^9.1.6",
     "slugid": "^1.1.0",
     "taskcluster-client": "^11.0.0",
-    "taskcluster-lib-api": "12.0.0",
+    "taskcluster-lib-api": "^12.0.2",
     "taskcluster-lib-app": "10.0.0",
     "taskcluster-lib-azure": "https://github.com/taskcluster/taskcluster-lib-azure#bug1460016",
     "taskcluster-lib-docs": "^10.0.0",

--- a/src/main.js
+++ b/src/main.js
@@ -104,8 +104,8 @@ var load = loader({
   },
 
   expire: {
-    requires: ['cfg', 'Secret'],
-    setup: async ({cfg, Secret}) => {
+    requires: ['cfg', 'Secret', 'monitor'],
+    setup: async ({cfg, Secret, monitor}) => {
       // Find an secret expiration delay
       var delay = cfg.app.secretExpirationDelay;
       var now   = taskcluster.fromNow(delay);
@@ -114,6 +114,9 @@ var load = loader({
       debug('Expiring secrets');
       let count = await Secret.expire(now);
       debug('Expired ' + count + ' secrets');
+      monitor.count('expire-secrets.done');
+      monitor.stopResourceMonitoring();
+      await monitor.flush();
     },
   },
 }, ['process', 'profile']);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2397,9 +2397,9 @@ taskcluster-client@^5.0.0:
     superagent "~3.8.1"
     taskcluster-lib-urls "^1.0.0"
 
-taskcluster-lib-api@12.0.0:
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/taskcluster-lib-api/-/taskcluster-lib-api-12.0.0.tgz#4ae1e54f16a5790cfff658ddb4a92b9f767cb393"
+taskcluster-lib-api@^12.0.2:
+  version "12.0.2"
+  resolved "https://registry.yarnpkg.com/taskcluster-lib-api/-/taskcluster-lib-api-12.0.2.tgz#af496b644694995002dbb383492f0219ddea7167"
   dependencies:
     ajv "^5.3.0"
     aws-sdk "^2.151.0"


### PR DESCRIPTION
I've gone ahead and added `FORCE_SSL` to the heroku configs. This also fixes the hang of the expire-secrets process.