### PR TITLE
tc-lib-app version upgrade in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "slugid": "^1.1.0",
     "taskcluster-client": "^11.0.0",
     "taskcluster-lib-api": "^12.6.0",
-    "taskcluster-lib-app": "10.0.0",
+    "taskcluster-lib-app": "10.2.0",
     "taskcluster-lib-azure": "^10.0.0",
     "taskcluster-lib-docs": "^10.0.0",
     "taskcluster-lib-loader": "^10.0.0",


### PR DESCRIPTION
Follow up fix for [tc-lib-app#26](https://github.com/taskcluster/taskcluster-lib-app/pull/26)